### PR TITLE
Quiz question numbers

### DIFF
--- a/app/views/hummingbird_survey/common/survey/_answer_item.html.haml
+++ b/app/views/hummingbird_survey/common/survey/_answer_item.html.haml
@@ -1,2 +1,2 @@
 .survey-answer-item{class: "#{"hide" unless survey_item.display?(f.object.all_answer_data)}", "data-parent" => survey_item.show_if_parent, "data-op" => survey_item.show_if_op, "data-val" => survey_item.show_if_val}
-  = render "hummingbird_survey/common/survey/answer_#{survey_item.survey_itemable_type.underscore}", f: f, survey_itemable: survey_item.survey_itemable
+  = render "hummingbird_survey/common/survey/answer_#{survey_item.survey_itemable_type.underscore}", f: f, survey_itemable: survey_item.survey_itemable, survey_item: survey_item

--- a/app/views/hummingbird_survey/common/survey/_answer_survey_question.html.haml
+++ b/app/views/hummingbird_survey/common/survey/_answer_survey_question.html.haml
@@ -1,17 +1,18 @@
+- item_label_html = "<em data-item-number='#{survey_itemable.item_number}}'></em>#{survey_itemable.label}".html_safe
 - case survey_itemable.question_type
   - when SurveyQuestionType::TextArea.new
-    = f.input "question_#{survey_itemable.id}", as: :text, label: survey_itemable.label, required: survey_itemable.required?
+    = f.input "question_#{survey_itemable.id}", as: :text, label: item_label_html, required: survey_itemable.required?
   - when SurveyQuestionType::RadioButtons.new
     - if survey_itemable.survey_item.survey.survey_type.quiz?
-      = f.input "question_#{survey_itemable.id}", as: :radio_buttons, label: survey_itemable.label, item_wrapper_class: "inline", collection: survey_itemable.survey_question_options, required: survey_itemable.required?
+      = f.input "question_#{survey_itemable.id}", as: :radio_buttons, label: item_label_html, item_wrapper_class: "inline", collection: survey_itemable.survey_question_options, required: survey_itemable.required?
     - else
-      = f.input "question_#{survey_itemable.id}", as: :radio_buttons, label: survey_itemable.label, item_wrapper_class: "inline", collection: survey_itemable.answer_list, required: survey_itemable.required?
+      = f.input "question_#{survey_itemable.id}", as: :radio_buttons, label: item_label_html, item_wrapper_class: "inline", collection: survey_itemable.answer_list, required: survey_itemable.required?
   - when SurveyQuestionType::MultiSelect.new
-    = f.input "question_#{survey_itemable.id}", as: :multi_select, label: survey_itemable.label, item_wrapper_class: "inline", collection: survey_itemable.answer_list, required: survey_itemable.required?
+    = f.input "question_#{survey_itemable.id}", as: :multi_select, label: item_label_html, item_wrapper_class: "inline", collection: survey_itemable.answer_list, required: survey_itemable.required?
   - when SurveyQuestionType::Checkbox.new
     = f.input "question_#{survey_itemable.id}", as: :boolean, label: false, item_wrapper_class: "inline", label_method: :to_s, value_method: :to_s, inline_label: survey_itemable.label, required: true
   - when SurveyQuestionType::Select.new
-    = f.input "question_#{survey_itemable.id}", as: :select, label: survey_itemable.label, required: survey_itemable.required?, item_wrapper_class: "inline", collection: survey_itemable.answer_list, label_method: :to_s, value_method: :to_s, input_html: { "data-placeholder" => "Please Select" }
+    = f.input "question_#{survey_itemable.id}", as: :select, label: item_label_html, required: survey_itemable.required?, item_wrapper_class: "inline", collection: survey_itemable.answer_list, label_method: :to_s, value_method: :to_s, input_html: { "data-placeholder" => "Please Select" }
   - when SurveyQuestionType::Signature.new
     = f.input "question_#{survey_itemable.id}", as: :signature, label: survey_itemable.label, required: survey_itemable.required?
   - when SurveyQuestionType::Review.new
@@ -19,10 +20,10 @@
   - when SurveyQuestionType::Agreement.new
     = f.input "question_#{survey_itemable.id}", as: :agreement, label: survey_itemable.agree_text, input_html: { agreement: survey_itemable.label.html_safe }, required: survey_itemable.required?
   - when SurveyQuestionType::CountrySelect.new
-    = render "common/address/country_select", form: f, field_name: "question_#{survey_itemable.id}", label: survey_itemable.label, required: survey_itemable.required?, country_select_id: "question_#{survey_itemable.id}_country"
+    = render "common/address/country_select", form: f, field_name: "question_#{survey_itemable.id}", label: item_label_html, required: survey_itemable.required?, country_select_id: "question_#{survey_itemable.id}_country"
   - when SurveyQuestionType::RegionSelect.new
-    = render "common/address/region_select", form: f, field_name: "question_#{survey_itemable.id}", label: survey_itemable.label, required: survey_itemable.required?, country_select_id: "question_#{survey_itemable.country_question_id}_country", country_code: f.object.all_answer_data["question_#{survey_itemable.country_question_id}"]
+    = render "common/address/region_select", form: f, field_name: "question_#{survey_itemable.id}", label: item_label_html, required: survey_itemable.required?, country_select_id: "question_#{survey_itemable.country_question_id}_country", country_code: f.object.all_answer_data["question_#{survey_itemable.country_question_id}"]
   - when SurveyQuestionType::Encrypted.new
-    = f.input "question_#{survey_itemable.id}", as: :encrypted, label: survey_itemable.label, required: survey_itemable.required?
+    = f.input "question_#{survey_itemable.id}", as: :encrypted, label: item_label_html, required: survey_itemable.required?
   - else
-    = f.input "question_#{survey_itemable.id}", label: survey_itemable.label, required: survey_itemable.required?
+    = f.input "question_#{survey_itemable.id}", label: item_label_html, required: survey_itemable.required?

--- a/app/views/hummingbird_survey/common/survey/_answer_survey_question.html.haml
+++ b/app/views/hummingbird_survey/common/survey/_answer_survey_question.html.haml
@@ -1,4 +1,4 @@
-- item_label_html = "<em data-item-number='#{survey_item.item_number}}'></em>#{survey_itemable.label}".html_safe
+- item_label_html = "<em data-item-number='#{survey_item.item_number}'></em>#{survey_itemable.label}".html_safe
 - case survey_itemable.question_type
   - when SurveyQuestionType::TextArea.new
     = f.input "question_#{survey_itemable.id}", as: :text, label: item_label_html, required: survey_itemable.required?

--- a/app/views/hummingbird_survey/common/survey/_answer_survey_question.html.haml
+++ b/app/views/hummingbird_survey/common/survey/_answer_survey_question.html.haml
@@ -1,4 +1,4 @@
-- item_label_html = "<em data-item-number='#{survey_itemable.item_number}}'></em>#{survey_itemable.label}".html_safe
+- item_label_html = "<em data-item-number='#{survey_item.item_number}}'></em>#{survey_itemable.label}".html_safe
 - case survey_itemable.question_type
   - when SurveyQuestionType::TextArea.new
     = f.input "question_#{survey_itemable.id}", as: :text, label: item_label_html, required: survey_itemable.required?

--- a/app/views/hummingbird_survey/common/survey/_show_question.html.haml
+++ b/app/views/hummingbird_survey/common/survey/_show_question.html.haml
@@ -1,7 +1,7 @@
 - unless SurveyQuestionType[item_options["question_type"]].review?
   - survey_question_type = SurveyQuestionType[item_options["question_type"]]
   .response-block{ id: "response-block-#{item_options["item_number"]}", class: "response-type-#{survey_question_type.to_s.dasherize}"}
-    .question-text{ id: "question-text-#{item_options["item_number"]}"}
+    .question-text{ id: "question-text-#{item_options["item_number"]}", "data-item-number": item_options["item_number"]}
       = item_options["label"].html_safe
     .response{ id: "response-#{item_options["item_number"]}"}
       = render "hummingbird_survey/common/survey/response/#{survey_question_type.response_partial}", item_options: item_options

--- a/app/views/staff/survey_items/_show.html.haml
+++ b/app/views/staff/survey_items/_show.html.haml
@@ -21,4 +21,4 @@
   .survey-iten-block
     .col-sm-12.col-md
       = simple_form_for SurveyPageForm.new(survey_page: survey_item.survey_page), url: "#" do |f|
-        = render "hummingbird_survey/common/survey/answer_#{survey_item.survey_itemable_type.underscore}", f: f, survey_itemable: survey_item.survey_itemable
+        = render "hummingbird_survey/common/survey/answer_#{survey_item.survey_itemable_type.underscore}", f: f, survey_itemable: survey_item.survey_itemable, survey_item: survey_item


### PR DESCRIPTION
Adds in the item number as a html data attribute that can then be extracted via css when needed (eg homework quiz) without disrupting other existing use of survey where item numbers are not needed to be displayed.